### PR TITLE
fix: parse.js script

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -4,7 +4,11 @@ if (!getModules) {
     function getModules(str) {
         webpackChunkdiscord_app.push([["discord-protos"], {}, r => cache=Object.values(r.c)]);
 
-        return filterMap(cache, x => Object.values(x.exports||{}).find(v=>v && v[str]))
+        return filterMap(cache, x => {
+			try {
+				return Object.values(x.exports||{}).find(v=>v && v[str])
+			} catch (e) {}
+		})
     }
 }
 


### PR DESCRIPTION
Previously parse.js failed with the following error:
```
Error: Evaluation failed: TypeError: Illegal invocation
    at Function.values (<anonymous>)
```
because Object.values was called on a DomTokenList class which couldn't be iterated.
To fix this error and any error in the future, a try catch was added.